### PR TITLE
Re-authenticate after changing credentials

### DIFF
--- a/R/get-statuses.R
+++ b/R/get-statuses.R
@@ -81,6 +81,7 @@ getStatuses <- function(ids=NULL, filename, oauth_folder, verbose=TRUE, sleep=1)
 
         ## changing oauth token if we hit the limit
         if (verbose){message(limit, " API calls left\n")}
+        cr_old <- cr
         while (limit==0){
             cr <- sample(creds, 1)
             if (verbose){message(cr, "\n")}
@@ -93,6 +94,13 @@ getStatuses <- function(ids=NULL, filename, oauth_folder, verbose=TRUE, sleep=1)
             }
             limit <- getLimitStatuses(my_oauth)
             if (verbose){message(limit, " API calls left\n")}
+        }
+        if (cr != cr_old) {
+            app <- httr::oauth_app("twitter", key = my_oauth$consumerKey, 
+                secret = my_oauth$consumerSecret)
+            credentials <- list(oauth_token = my_oauth$oauthKey, oauth_token_secret = my_oauth$oauthSecret)
+            twitter_token <- httr::Token1.0$new(endpoint = NULL, params = list(as_header = TRUE), 
+                app = app, credentials = credentials)
         }
     }
 }


### PR DESCRIPTION
Hey,
not 100% sure about this but don't you have to re-authenticate after changing the oauth token? Once the function hits the limit, the second while loop randomly picks one of the credentials in `oauth_folder` until getting a credential with non-zero limit. If we end up with different credentials at the end of that process, we have to authenticate with the new token, no? My changes do that by a) adding `cr_old <- cr` before the loop to save the old credentials and b) adding a if condition after the loop that re-authenticate with the new token if `cr != cr_old`.

Best!
